### PR TITLE
fix: thrift 3950 memory leak while calling oneway methods

### DIFF
--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -1565,7 +1565,14 @@ void t_js_generator::generate_service_client(t_service* tservice) {
                << ".writeMessageEnd();" << endl;
 
     if (gen_node_) {
-      f_service_ << indent() << "return this.output.flush();" << endl;
+      if((*f_iter)->is_oneway()) {
+        f_service_ << indent() << "this.output.flush();" << endl;
+        f_service_ << indent() << "var callback = this._reqs[this.seqid()] || function() {};" << endl;
+        f_service_ << indent() << "delete this._reqs[this.seqid()];" << endl;
+        f_service_ << indent() << "callback(null);" << endl;
+      } else {
+        f_service_ << indent() << "return this.output.flush();" << endl;
+      }
     } else {
       if (gen_jquery_) {
         f_service_ << indent() << "return this.output.getTransport().flush(callback);" << endl;

--- a/lib/nodejs/test/test_driver.js
+++ b/lib/nodejs/test/test_driver.js
@@ -125,7 +125,8 @@ exports.ThriftTestDriver = function(client, callback) {
     });
 
     client.testOneway(0, function(err, response) {
-      assert.fail('testOneway should not answer');
+      assert.error(err, 'testOneway: no callback error');
+      assert.strictEqual(response, undefined, 'testOneway: void response');
     });
 
     checkOffByOne(function(done) {
@@ -223,7 +224,11 @@ exports.ThriftTestDriverPromise = function(client, callback) {
       })
       .fail(fail('testException'));
 
-    client.testOneway(0, fail('testOneway: should not answer'));
+    client.testOneway(0)
+      .then(function(response) {
+        assert.strictEqual(response, undefined, 'testOneway: void response')
+      })
+      .fail(fail('testOneway: should not reject'));
 
     checkOffByOne(function(done) {
       client.testI32(-1)


### PR DESCRIPTION
Apply https://github.com/apache/thrift/pull/1568 patch